### PR TITLE
Stopped server blowing up after files are changed and contain errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -48,7 +48,7 @@
           extended: false
         })).get('*', get).post('*', post);
         bundler.bundle(options.paths, options.environment === 'development', function(ids){
-          var done, id, parents;
+          var done, id, parents, e;
           done = [];
           while (id = first(ids)) {
             parents = map(fn$)(
@@ -66,7 +66,12 @@
             return ref1$ = (ref$ = require.cache)[it], delete ref$[it], ref1$;
           })(
           done);
-          return app = require(options.paths.app.rel);
+          try {
+            return app = require(options.paths.app.rel);
+          } catch (e$) {
+            e = e$;
+            return console.error('Error in changed files when restarting server');
+          }
           function fn$(it){
             return it.id;
           }

--- a/src/server.ls
+++ b/src/server.ls
@@ -50,7 +50,10 @@ module.exports = (options) ->
 
       done |> each -> delete require.cache[it]
 
-      app := require options.paths.app.rel
+      try
+        app := require options.paths.app.rel
+      catch
+        console.error 'Error in changed files when restarting server'
 
     if cb
       listener = server.listen options.port, (err) ->


### PR DESCRIPTION
To reproduce:

* Generate new arch app and start it
* In `app.ls` change the require of `./routes/welcome` to `./routes/whatever` and save
* An error is thrown in `server.js/ls` after the changed files have been purged from the require cache and `app` is required again

I've wrapped the require of the new `app` in a try/catch so that if there is an error the server won't crash. This way the existing `app` instance is kept in memory along with all state. I put a `console.error` in there so you get some feedback too. After you've fixed the error the new instance is required again and the app updates in the browser like normal.