### PR TITLE
Fix for `dangerouslySetInnerHTML` failing

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -36,7 +36,7 @@
       children = args;
       props = {};
     }
-    props.children = children && children.length === 1 ? children[0] : children;
+    props.children = !empty(children) ? children.length === 1 ? children[0] : children : void 8;
     return React.createElement(el, props);
   };
   dom = function(el){

--- a/src/dom.ls
+++ b/src/dom.ls
@@ -25,7 +25,9 @@ component = (el, args) ->
     children = args
     props = {}
 
-  props.children = (if children and children.length is 1 then children[0] else children)
+  props.children =
+    unless empty children
+      if children.length is 1 then children[0] else children
 
   React.create-element el, props
 


### PR DESCRIPTION
Using `dangerouslySetInnerHTML` currently throws an error as `dom` passes `[]` even if no children were specified:

```
Unhandled rejection Error: Invariant Violation: Can only set one of `children` or `props.dangerouslySetInnerHTML`.
```

I've added a check in the `component` function in `dom` to set `props.children` to `void` if no children were specified.