### PR TITLE
[Fix] Bind route get-title call to the route component instance

### DIFF
--- a/lib/virtual-dom-utils.js
+++ b/lib/virtual-dom-utils.js
@@ -33,7 +33,7 @@
   routeMetadata = function(tree){
     var route, title, that;
     route = extractRoute(tree);
-    title = (that = route.getTitle) ? that() : "";
+    title = (that = route.getTitle) ? that.call(route) : "";
     return {
       title: title,
       layout: route.getLayoutTemplate()

--- a/src/virtual-dom-utils.ls
+++ b/src/virtual-dom-utils.ls
@@ -24,7 +24,7 @@ form-elements = (tree, path, input-names) ->
 route-metadata = (tree) ->
   route = extract-route tree
 
-  title = if route.get-title then that! else ""
+  title = if route.get-title then that.call route else ""
 
   # collect all the metadata
   title: title


### PR DESCRIPTION
This gives you the correct `this` context in the component's `get-title` call.